### PR TITLE
Added debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The `NewS2DBArrowReader` function takes `S2DBArrowReaderConfig` as a parameter. 
 | Args               | nil (no arguments)    | Arguments for placeholder parameters in the query.
 | RecordSize         | 10000                 | The maximum number of rows in the resulting records.
 | ParallelReadConfig | nil (sequential read) | Additional configurations for parallel read. If this value is non-`nil`, parallel read is enabled.
+| EnableDebugLogging | false                 | Controls whether the driver should generate debug logs. Debug logs are printed to the standard output.
 
 The `S2DBParallelReadConfig` allows you to configure additional settings for parallel read. Here are the additional configurations that can be set:
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ The `NewS2DBArrowReader` function takes `S2DBArrowReaderConfig` as a parameter. 
 | Args               | nil (no arguments)    | Arguments for placeholder parameters in the query.
 | RecordSize         | 10000                 | The maximum number of rows in the resulting records.
 | ParallelReadConfig | nil (sequential read) | Additional configurations for parallel read. If this value is non-`nil`, parallel read is enabled.
-| EnableDebugLogging | false                 | Controls whether the driver should generate debug logs. Debug logs are printed to the standard output.
+| EnableQueryLogging | false                 | Controls whether the driver should generate debug logs. Debug logs are printed to the standard output.
 
 The `S2DBParallelReadConfig` allows you to configure additional settings for parallel read. Here are the additional configurations that can be set:
 
-| Name               | Default               | Description  | 
-| :------------------| :-------------------- | :----------- |
-| DatabaseName       | No default (required) | The name of the SingleStoreDB database. It is used to determine the number of partitions for parallel reading.
-| ChannelSize        | 10000                 | The size of the channel buffer. The channel stores references to Arrow Records while reading is in progress and transfers them to the main `goroutine`.
+| Name                 | Default               | Description  | 
+| :------------------- | :-------------------- | :----------- |
+| DatabaseName         | No default (required) | The name of the SingleStoreDB database. It is used to determine the number of partitions for parallel reading.
+| ChannelSize          | 10000                 | The size of the channel buffer. The channel stores references to Arrow Records while reading is in progress and transfers them to the main `goroutine`.
+| EnableDebugProfiling | false                 | Controls whether to profile the query. Profiling result is printed to the standart output.
 
 > note: 
 Set `interpolateParams=true` parameter of the `sql.DB` in order to use parallel read.

--- a/debug_util.go
+++ b/debug_util.go
@@ -1,0 +1,66 @@
+package s2db_arrow_driver
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func logQueryExecution(loggingEnabled bool, query string, args ...interface{}) {
+	if loggingEnabled {
+		fmt.Printf("Executing query (query: '%s', args: '%v')\n", query, args)
+	}
+}
+
+func profileQuery(loggingEnabled bool, ctx context.Context, conn *sql.Conn, query string) {
+	if !loggingEnabled {
+		return
+	}
+
+	execute := func(query string) error {
+		logQueryExecution(loggingEnabled, query)
+		_, err := conn.ExecContext(ctx, query)
+		if err != nil {
+			fmt.Printf("Failed to perform profiling (%s)\n", err)
+			return err
+		}
+
+		return nil
+	}
+
+	err := execute(fmt.Sprintf("CREATE TEMPORARY TABLE temp AS SELECT * FROM (%s) LIMIT 0", query))
+	if err != nil {
+		return
+	}
+	defer execute("DROP TEMPORARY TABLE temp")
+	execute("SET SESSION profile_for_debug=1")
+	if err != nil {
+		return
+	}
+	defer execute("SET SESSION profile_for_debug=0")
+	execute(fmt.Sprintf("PROFILE INSERT INTO temp SELECT * FROM (%s)", query))
+	if err != nil {
+		return
+	}
+
+	rows, err := conn.QueryContext(ctx, "SHOW PROFILE JSON")
+	if err != nil {
+		fmt.Printf("Failed to perform profiling (%s)\n", err)
+		return
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		fmt.Println("Failed to perform profiling (SHOW PROFILE returned empty result)")
+		return
+	}
+
+	var profile string
+	rows.Scan(&profile)
+	if err != nil {
+		fmt.Printf("Failed to perform profiling (%s)\n", err)
+		return
+	}
+
+	fmt.Printf("Profiling result:\n%s\n", profile)
+}

--- a/s2db_arrow_reader.go
+++ b/s2db_arrow_reader.go
@@ -32,6 +32,9 @@ type S2DBArrowReaderConfig struct {
 	// ParallelReadConfig specifies aditional configurations for parallel read
 	// By default it is nil and it means that parallel read is not used
 	ParallelReadConfig *S2DBParallelReadConfig
+	// EnableDebugLogging controls whether the driver should generate debug logs
+	// Debug logs are printed to the standard output
+	EnableDebugLogging bool
 }
 
 type S2DBParallelReadConfig struct {

--- a/s2db_arrow_reader.go
+++ b/s2db_arrow_reader.go
@@ -32,9 +32,9 @@ type S2DBArrowReaderConfig struct {
 	// ParallelReadConfig specifies aditional configurations for parallel read
 	// By default it is nil and it means that parallel read is not used
 	ParallelReadConfig *S2DBParallelReadConfig
-	// EnableDebugLogging controls whether the driver should generate debug logs
+	// EnableQueryLogging controls whether the driver should generate debug logs
 	// Debug logs are printed to the standard output
-	EnableDebugLogging bool
+	EnableQueryLogging bool
 }
 
 type S2DBParallelReadConfig struct {
@@ -46,6 +46,9 @@ type S2DBParallelReadConfig struct {
 	// and transfer them to the main goroutine
 	// The default value is 10000
 	ChannelSize int64
+	// Controls whether to profile the query
+	// Profiling result is printed to the standart output
+	EnableDebugProfiling bool
 }
 
 // NewS2DBArrowReader creates an instance of S2DBArrowReader

--- a/s2db_arrow_reader_impl.go
+++ b/s2db_arrow_reader_impl.go
@@ -22,8 +22,7 @@ type S2DBArrowReaderImpl struct {
 
 func NewS2DBArrowReaderImpl(ctx context.Context, conf S2DBArrowReaderConfig) (S2DBArrowReader, error) {
 	var err error = nil
-	logQueryExecution(conf.EnableDebugLogging, conf.Query, conf.Args...)
-	rows, err := conf.Conn.QueryContext(ctx, conf.Query, conf.Args...)
+	rows, err := queryContext(ctx, conf.Conn, conf.Query, conf.EnableDebugLogging, conf.Args...)
 	if err != nil {
 		return nil, err
 	}

--- a/s2db_arrow_reader_impl.go
+++ b/s2db_arrow_reader_impl.go
@@ -22,7 +22,7 @@ type S2DBArrowReaderImpl struct {
 
 func NewS2DBArrowReaderImpl(ctx context.Context, conf S2DBArrowReaderConfig) (S2DBArrowReader, error) {
 	var err error = nil
-	rows, err := queryContext(ctx, conf.Conn, conf.Query, conf.EnableDebugLogging, conf.Args...)
+	rows, err := queryContext(ctx, conf.Conn, conf.Query, conf.EnableQueryLogging, conf.Args...)
 	if err != nil {
 		return nil, err
 	}

--- a/s2db_arrow_reader_impl.go
+++ b/s2db_arrow_reader_impl.go
@@ -22,6 +22,7 @@ type S2DBArrowReaderImpl struct {
 
 func NewS2DBArrowReaderImpl(ctx context.Context, conf S2DBArrowReaderConfig) (S2DBArrowReader, error) {
 	var err error = nil
+	logQueryExecution(conf.EnableDebugLogging, conf.Query, conf.Args...)
 	rows, err := conf.Conn.QueryContext(ctx, conf.Query, conf.Args...)
 	if err != nil {
 		return nil, err

--- a/s2db_arrow_reader_parallel_impl.go
+++ b/s2db_arrow_reader_parallel_impl.go
@@ -27,8 +27,7 @@ type S2DBArrowReaderParallelImpl struct {
 
 func getPartitionsCount(ctx context.Context, conn S2SqlDbWrapper, database string, loggingEnabled bool) (int32, error) {
 	query := fmt.Sprintf("SELECT num_partitions FROM information_schema.DISTRIBUTED_DATABASES WHERE database_name = '%s'", database)
-	logQueryExecution(loggingEnabled, query)
-	rows, err := conn.QueryContext(ctx, query)
+	rows, err := queryContext(ctx, conn, query, loggingEnabled)
 	if err != nil {
 		return 0, err
 	}
@@ -67,16 +66,14 @@ func NewS2DBArrowReaderParallelImpl(ctx context.Context, conf S2DBArrowReaderCon
 
 	resultTableName := generateTableName(conf.Query)
 	createResultTableQuery := fmt.Sprintf("CREATE RESULT TABLE `%s` AS SELECT * FROM (%s)", resultTableName, conf.Query)
-	profileQuery(conf.EnableDebugLogging, ctx, resultTableConn, conf.Query)
-	logQueryExecution(conf.EnableDebugLogging, createResultTableQuery, conf.Args)
-	if _, err = resultTableConn.ExecContext(ctx, createResultTableQuery, conf.Args...); err != nil {
+	profileQuery(conf.EnableDebugLogging, ctx, resultTableConn, conf.Query, conf.Args...)
+	if _, err = execContext(ctx, resultTableConn, createResultTableQuery, conf.EnableDebugLogging, conf.Args...); err != nil {
 		return nil, err
 	}
 	defer func() {
 		if err != nil {
 			dropQuery := fmt.Sprintf("DROP RESULT TABLE `%s`", resultTableName)
-			logQueryExecution(conf.EnableDebugLogging, dropQuery)
-			resultTableConn.ExecContext(ctx, dropQuery)
+			execContext(ctx, resultTableConn, dropQuery, conf.EnableDebugLogging)
 		}
 	}()
 
@@ -143,8 +140,7 @@ func (s2db *S2DBArrowReaderParallelImpl) GetNextArrowRecordBatch() (arrow.Record
 func (s2db *S2DBArrowReaderParallelImpl) Close() error {
 	if s2db.resultTableConn != nil {
 		dropQuery := fmt.Sprintf("DROP RESULT TABLE `%s`", s2db.resultTableName)
-		logQueryExecution(s2db.enableDebugLogging, dropQuery)
-		s2db.resultTableConn.ExecContext(s2db.ctx, dropQuery)
+		execContext(s2db.ctx, s2db.resultTableConn, dropQuery, s2db.enableDebugLogging)
 		return s2db.resultTableConn.Close()
 	}
 

--- a/s2db_arrow_reader_parallel_impl.go
+++ b/s2db_arrow_reader_parallel_impl.go
@@ -14,18 +14,21 @@ import (
 )
 
 type S2DBArrowReaderParallelImpl struct {
-	conn            S2SqlDbWrapper
-	databaseName    string
-	channelSize     int64
-	resultTableConn *sql.Conn
-	resultTableName string
-	ch              chan arrow.Record
-	errorGroup      *errgroup.Group
-	ctx             context.Context
+	conn               S2SqlDbWrapper
+	databaseName       string
+	channelSize        int64
+	resultTableConn    *sql.Conn
+	resultTableName    string
+	ch                 chan arrow.Record
+	errorGroup         *errgroup.Group
+	ctx                context.Context
+	enableDebugLogging bool
 }
 
-func getPartitionsCount(ctx context.Context, conn S2SqlDbWrapper, database string) (int32, error) {
-	rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT num_partitions FROM information_schema.DISTRIBUTED_DATABASES WHERE database_name = '%s'", database))
+func getPartitionsCount(ctx context.Context, conn S2SqlDbWrapper, database string, loggingEnabled bool) (int32, error) {
+	query := fmt.Sprintf("SELECT num_partitions FROM information_schema.DISTRIBUTED_DATABASES WHERE database_name = '%s'", database)
+	logQueryExecution(loggingEnabled, query)
+	rows, err := conn.QueryContext(ctx, query)
 	if err != nil {
 		return 0, err
 	}
@@ -47,7 +50,7 @@ func generateTableName(query string) string {
 }
 
 func NewS2DBArrowReaderParallelImpl(ctx context.Context, conf S2DBArrowReaderConfig) (S2DBArrowReader, error) {
-	partitions, err := getPartitionsCount(ctx, conf.Conn, conf.ParallelReadConfig.DatabaseName)
+	partitions, err := getPartitionsCount(ctx, conf.Conn, conf.ParallelReadConfig.DatabaseName, conf.EnableDebugLogging)
 	if err != nil {
 		return nil, err
 	}
@@ -64,13 +67,16 @@ func NewS2DBArrowReaderParallelImpl(ctx context.Context, conf S2DBArrowReaderCon
 
 	resultTableName := generateTableName(conf.Query)
 	createResultTableQuery := fmt.Sprintf("CREATE RESULT TABLE `%s` AS SELECT * FROM (%s)", resultTableName, conf.Query)
+	profileQuery(conf.EnableDebugLogging, ctx, resultTableConn, conf.Query)
+	logQueryExecution(conf.EnableDebugLogging, createResultTableQuery, conf.Args)
 	if _, err = resultTableConn.ExecContext(ctx, createResultTableQuery, conf.Args...); err != nil {
 		return nil, err
 	}
 	defer func() {
 		if err != nil {
-			resultTableConn.ExecContext(ctx,
-				fmt.Sprintf("DROP RESULT TABLE `%s`", resultTableName))
+			dropQuery := fmt.Sprintf("DROP RESULT TABLE `%s`", resultTableName)
+			logQueryExecution(conf.EnableDebugLogging, dropQuery)
+			resultTableConn.ExecContext(ctx, dropQuery)
 		}
 	}()
 
@@ -89,9 +95,10 @@ func NewS2DBArrowReaderParallelImpl(ctx context.Context, conf S2DBArrowReaderCon
 				}()
 
 				arrowReader, err := NewS2DBArrowReader(ctx, S2DBArrowReaderConfig{
-					Conn:       conf.Conn,
-					Query:      fmt.Sprintf("SELECT * FROM ::`%s` WHERE partition_id() = %d", resultTableName, partition),
-					RecordSize: conf.RecordSize,
+					Conn:               conf.Conn,
+					Query:              fmt.Sprintf("SELECT * FROM ::`%s` WHERE partition_id() = %d", resultTableName, partition),
+					RecordSize:         conf.RecordSize,
+					EnableDebugLogging: conf.EnableDebugLogging,
 				})
 				if err != nil {
 					return err
@@ -112,14 +119,15 @@ func NewS2DBArrowReaderParallelImpl(ctx context.Context, conf S2DBArrowReaderCon
 	}
 
 	return &S2DBArrowReaderParallelImpl{
-		conn:            conf.Conn,
-		databaseName:    conf.ParallelReadConfig.DatabaseName,
-		channelSize:     conf.ParallelReadConfig.ChannelSize,
-		resultTableConn: resultTableConn,
-		resultTableName: resultTableName,
-		ch:              ch,
-		errorGroup:      errorGroup,
-		ctx:             ctx,
+		conn:               conf.Conn,
+		databaseName:       conf.ParallelReadConfig.DatabaseName,
+		channelSize:        conf.ParallelReadConfig.ChannelSize,
+		resultTableConn:    resultTableConn,
+		resultTableName:    resultTableName,
+		ch:                 ch,
+		errorGroup:         errorGroup,
+		ctx:                ctx,
+		enableDebugLogging: conf.EnableDebugLogging,
 	}, nil
 }
 
@@ -134,8 +142,9 @@ func (s2db *S2DBArrowReaderParallelImpl) GetNextArrowRecordBatch() (arrow.Record
 
 func (s2db *S2DBArrowReaderParallelImpl) Close() error {
 	if s2db.resultTableConn != nil {
-		s2db.resultTableConn.ExecContext(s2db.ctx,
-			fmt.Sprintf("DROP RESULT TABLE `%s`", s2db.resultTableName))
+		dropQuery := fmt.Sprintf("DROP RESULT TABLE `%s`", s2db.resultTableName)
+		logQueryExecution(s2db.enableDebugLogging, dropQuery)
+		s2db.resultTableConn.ExecContext(s2db.ctx, dropQuery)
 		return s2db.resultTableConn.Close()
 	}
 

--- a/s2db_arrow_reader_test.go
+++ b/s2db_arrow_reader_test.go
@@ -80,9 +80,8 @@ func readParallel(conn *sql.DB, query string) error {
 
 func readArrow(conn *sql.DB, query string) error {
 	arrowReader, err := NewS2DBArrowReader(context.Background(), S2DBArrowReaderConfig{
-		Conn:               conn,
-		Query:              query,
-		EnableDebugLogging: true,
+		Conn:  conn,
+		Query: query,
 	})
 	if err != nil {
 		return err
@@ -106,7 +105,6 @@ func readArrowParallel(conn *sql.DB, query string) error {
 		ParallelReadConfig: &S2DBParallelReadConfig{
 			DatabaseName: "db",
 		},
-		EnableDebugLogging: true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Added logs before query is executed.
Added profiling of the parallel query.

Output example:
```
Executing query (query: 'SELECT num_partitions FROM information_schema.DISTRIBUTED_DATABASES WHERE database_name = 'db'', args: '[]')
Executing query (query: 'CREATE TEMPORARY TABLE temp AS SELECT * FROM (SELECT * FROM t) LIMIT 0', args: '[]')
Executing query (query: 'SET SESSION profile_for_debug=1', args: '[]')
Executing query (query: 'PROFILE INSERT INTO temp SELECT * FROM (SELECT * FROM t)', args: '[]')
Profiling result:
{
    "plan_warnings": {
},
    "execution_warnings": {
},
    "mpl_path":"\/var\/lib\/memsql\/e93fcb5b-e2a7-4a36-8cbb-7f8308dca4c8\/plancache\/214\/InsertSelect_profile_temp__et_al_214f693b89df494e49df2e5e45f86b757d154249453952272a0e4a45c0b4699e_06bd906a6e6389b1",
    "profile":[
        {
            "executor":"Gather",
            "keyId":4295163904,
            "partitions":"all",
            "est_rows":"1000000",
            "est_rows_source":"JOIN",
            "query":"INSERT INTO `db_0`.`temp` (`temp`.`a`, `temp`.`b`, `temp`.`t`)SELECT STRAIGHT_JOIN `unaliased subselect`.`a` AS `a`, `unaliased subselect`.`b` AS `b`, `unaliased subselect`.`t` AS `t` FROM `db_0`.`t` as `unaliased subselect`  \/*!90623 OPTION(NO_QUERY_REWRITE=1, INTERPRETER_MODE=INTERPRET_FIRST)*\/",
            "alias":"remote_0",
            "parallelism_level":"partition",
            "actual_row_count":{ "value":1000000, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "actual_total_time":{ "value":0 },
            "mbc_emission":{ "value":3, "avg":3.000000, "stddev":0.000000, "max":3, "maxPartition":0 },
            "create_mbc_context":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "optimizer_query_rewrites":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "optimizer_setting_up_subselect":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "optimizer_distributed_optimizations":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "optimizer_enumerate_temporary_tables":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "generating_query_mpl":{ "value":1, "avg":1.000000, "stddev":0.000000, "max":1, "maxPartition":0 },
            "generating_user_function_mpl":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
            "unknown":{ "value":10, "avg":10.000000, "stddev":0.000000, "max":10, "maxPartition":0 },
            "total":{ "value":12, "avg":12.000000, "stddev":0.000000, "max":12, "maxPartition":0 },
            "inputs":[
                {
                    "executor":"InsertInto",
                    "keyId":196750,
                    "db":"db",
                    "table":"temp",
                    "out":[
                        {
                            "alias":"",
                            "projection":"`unaliased subselect`.a"
                            },
                        {
                            "alias":"",
                            "projection":"`unaliased subselect`.b"
                            },
                        {
                            "alias":"",
                            "projection":"`unaliased subselect`.t"
                            }
                        ],
                    "local":"yes",
                    "est_rows":"1000000",
                    "est_rows_source":"JOIN",
                    "subselects":[],
                    "actual_row_count":{ "value":1000000, "avg":125000.000000, "stddev":438.836530, "max":125607, "maxPartition":1 },
                    "actual_total_time":{ "value":66, "avg":66.000000, "stddev":0.000000, "max":66, "maxPartition":0 },
                    "start_time":{ "value":14, "avg":14.625000, "stddev":0.000000, "max":15, "maxPartition":0 },
                    "SegmentCount":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                    "SegmentSort":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                    "DupCheckInStager":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                    "SegmentCompress":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                    "AutoStats":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                    "inputs":[
                        {
                            "executor":"ColumnStoreScan",
                            "keyId":8590196736,
                            "db":"db",
                            "table":"t",
                            "alias":"unaliased subselect",
                            "index":"KEY __UNORDERED () USING CLUSTERED COLUMNSTORE",
                            "storage":"columnar",
                            "table_type":"sharded_columnstore",
                            "columnstore_in_memory_scan_type":"TableScan",
                            "columnstore_in_memory_scan_index":"KEY __UNORDERED () USING CLUSTERED COLUMNSTORE",
                            "est_table_rows":"1000000",
                            "est_filtered":"1000000",
                            "est_filtered_source":"DEFAULT",
                            "actual_row_count":{ "value":1000000, "avg":125000.000000, "stddev":438.836530, "max":125607, "maxPartition":1 },
                            "actual_total_time":{ "value":44, "avg":44.000000, "stddev":0.000000, "max":44, "maxPartition":0 },
                            "start_time":{ "value":12, "avg":12.625000, "stddev":0.000000, "max":13, "maxPartition":0 },
                            "memory_usage":{ "value":1048576, "avg":131072.000000, "stddev":0.000000, "max":131072, "maxPartition":0 },
                            "segments_scanned":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                            "segments_skipped":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                            "segments_fully_contained":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                            "segments_filter_encoded_data":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                            "columngroup_read_rows":{ "value":0, "avg":0.000000, "stddev":0.000000, "max":0, "maxPartition":0 },
                            "columnstore_read_rows":{ "value":1000000, "avg":125000.000000, "stddev":438.836530, "max":125607, "maxPartition":1 },
                            "inputs":[]
                            }
                        ]
                    }
                ]
            }
        ],
    "version":"4",
    "warning":"requires compile",
    "info":{
        "memsql_version":"8.0.15",
        "memsql_version_hash":"0b9b66384f1e18c3b80a24ca64c996861a0b0255",
        "num_online_leaves":"1",
        "num_online_aggs":"2",
        "context_database":"db"
        },
    "query_info":{
        "query_text":"PROFILE INSERT INTO temp SELECT * FROM (SELECT * FROM t)",
        "total_runtime_ms":"340",
        "agg_node":"127.0.0.1",
        "text_profile":"Gather partitions:all est_rows:1,000,000 alias:remote_0 parallelism_level:partition actual_rows: 1,000,000 exec_time: 0ms\nInsertInto db.temp [`unaliased subselect`.a, `unaliased subselect`.b, `unaliased subselect`.t] local:yes est_rows:1,000,000 actual_rows: 1,000,000 exec_time: 66ms start_time: [00:00:00.014, 00:00:00.015] Segment Count: 0 Segment Sort: 0ms Dup Check: 0ms Segment Compress: 0ms Auto Stats: 0ms\nColumnStoreScan db.t AS `unaliased subselect`, KEY __UNORDERED () USING CLUSTERED COLUMNSTORE table_type:sharded_columnstore est_table_rows:1,000,000 est_filtered:1,000,000 actual_rows: 1,000,000 exec_time: 44ms start_time: [00:00:00.012, 00:00:00.013] memory_usage: 1,048.576050 KB segments_scanned: 0 segments_skipped: 0 segments_fully_contained: 0 columngroup_read_rows: 0 columnstore_read_rows: 1,000,000\nCompile Total Time: 10ms\n",
        "compile_time_stats":{
            "mbc_emission":"1",
            "create_mbc_context":"0",
            "optimizer_query_rewrites":"0",
            "optimizer_stats_analyze":"0",
            "optimizer_stats_other":"0",
            "optimizer_setting_up_subselect":"0",
            "optimizer_distributed_optimizations":"0",
            "optimizer_enumerate_temporary_tables":"0",
            "optimizer_singlebox_optimizations_agg":"0",
            "optimizer_stats_autostats":"0",
            "optimizer_dstree_rewrites":"0",
            "generating_query_mpl":"0",
            "generating_user_function_mpl":"0",
            "unknown":"6",
            "total":"10"
            },
        "optimizer_optree_memory":"39192",
        "optimizer_dstree_memory":"26136"
        },
    "debug_info":{
        "autostats_cache":[
            {
                "db":"db",
                "table":"t",
                "rowcount":"1000000",
                "columns":[
                    {
                        "column_name":"a",
                        "null_count":"0",
                        "cardinality":"0",
                        "current":"0"
                        },
                    {
                        "column_name":"b",
                        "null_count":"0",
                        "cardinality":"0",
                        "current":"0"
                        },
                    {
                        "column_name":"t",
                        "null_count":"0",
                        "cardinality":"0",
                        "current":"0"
                        }
                    ]
                }
            ],
        "ddl":[
    "CREATE DATABASE `db` PARTITIONS 8",
    "USING `db` CREATE TABLE `t` (\n  `a` bigint(20) NOT NULL,\n  `b` double DEFAULT NULL,\n  `t` text CHARACTER SET utf8 COLLATE utf8_general_ci,\n  UNIQUE KEY `PRIMARY` (`a`) USING HASH,\n  SHARD KEY `__SHARDKEY` (`a`),\n  KEY `__UNORDERED` () USING CLUSTERED COLUMNSTORE\n) AUTOSTATS_CARDINALITY_MODE=INCREMENTAL AUTOSTATS_HISTOGRAM_MODE=CREATE AUTOSTATS_SAMPLING=ON SQL_MODE='STRICT_ALL_TABLES'",
    "USING `db` CREATE TEMPORARY TABLE `temp` (\n  `a` bigint(20) DEFAULT NULL,\n  `b` double DEFAULT NULL,\n  `t` text CHARACTER SET utf8 COLLATE utf8_general_ci,\n  KEY `__UNORDERED` () USING CLUSTERED COLUMNSTORE\n  , SHARD KEY () \n) SQL_MODE='STRICT_ALL_TABLES'"
],
        "variables":{"as_aggregator": 1, "as_leaf": 0, "batch_external_functions": 0, "binary_serialization": 1, "clamp_histogram_date_estimates": 2, "client_found_rows": 0, "collation_server": 2, "datetime_precision_mode": 0, "default_columnstore_table_lock_threshold": 0, "default_spill_dependent_outputters": 0, "disable_histogram_estimation": 0, "disable_remove_redundant_gby_rewrite": 3, "disable_sampling_estimation": 0, "disable_sampling_estimation_with_histograms": 2, "disable_subquery_merge_with_straight_joins": 2, "display_full_estimation_stats": 0, "distributed_optimizer_broadcast_mult": 0, "distributed_optimizer_estimated_restricted_search_cost_bound": 125, "distributed_optimizer_max_join_size": 22, "distributed_optimizer_min_join_size_run_initial_heuristics": 16, "distributed_optimizer_nodes": 0, "distributed_optimizer_old_selectivity_table_threshold": 22, "distributed_optimizer_run_legacy_heuristic": 0, "distributed_optimizer_selectivity_fallback_threshold": 50000000, "distributed_optimizer_unrestricted_search_threshold": 22, "enable_broadcast_left_join": 1, "enable_histogram_to_unwrap_literals": 2, "enable_local_shuffle_group_by": 1, "enable_multipartition_queries": 1, "enable_skiplist_sampling_for_selectivity": 1, "estimate_zero_rows_when_sampling_data_is_missing": 0, "exclude_scalar_subselects_from_filters": 0, "force_bloom_filters": 0, "force_bushy_join_table_limit": 18, "force_bushy_joins": 0, "force_heuristic_rewrites": 0, "force_table_pushdown": 0, "hash_groupby_segment_distinct_values_threshold": 10000, "histogram_column_correlation": 0.500000, "ignore_insert_into_computed_column": 0, "inlist_precision_limit": 10000, "interpreter_mode": 4, "leaf_pushdown_default": 0, "leaf_pushdown_enable_rowcount": 120000, "materialize_ctes": 1, "max_broadcast_tree_rowcount": 120000, "max_subselect_aggregator_rowcount": 120000, "old_local_join_optimizer": 0, "optimize_constants": 1, "optimize_mpl_before_printing": 0, "optimize_stmt_threshold": 50, "optimizer_beam_width": 10, "optimizer_cross_join_cost": 1.000000, "optimizer_disable_right_join": 0, "optimizer_disable_subselect_to_join": 0, "optimizer_empty_tables_limit": 0, "optimizer_enable_json_text_matching": 0, "optimizer_enable_orderby_limit_self_join": 0, "optimizer_hash_join_cost": 1.000000, "optimizer_merge_join_cost": 1.000000, "optimizer_nested_join_cost": 1.000000, "optimizer_num_partitions": 0, "quadratic_rewrite_size_limit": 200, "query_rewrite_loop_iterations": 1, "reshuffle_group_by_base_cost": 0, "sampling_estimates_for_complex_filters": 1, "singlebox_optimizer_cost_based_threshold": 18, "sql_mode": 4194304, "sql_select_limit": 1, "subquery_merge_with_outer_joins": 3, "verify_fields_in_transitivity": 2, "cardinality_estimation_level": 4, "data_conversion_compatibility_level": 4, "debug_mode": 0, "default_partitions_per_leaf": 8, "disable_update_delete_distributed_transactions": 0, "enable_alias_space_trim": 0, "enable_spilling": 1, "explicit_defaults_for_timestamp": 1, "json_compatibility_level": 0, "json_extract_string_collation": 3, "resource_pool_statement_selector_function": 4294967300, "use_avx2": 1, "use_dstree": 1, "use_joincolumnstore": 1, "flexible_parallelism_enabled": 1, "resource_pool_is_auto": 0},
        "optimizer_stats":[
    {
    "version": 2,
    "databaseName": "db",
    "tables": [
        {
            "tableName": "t",
            "rowCount": "0",
            "columns": [
                {
                    "columnName": "a",
                    "nullCount": "0",
                    "minValue": "",
                    "maxValue": "",
                    "cardinality": "0",
                    "density": "0x0p+0",
                    "sampleSize": "0",
                    "lastUpdated": "0"
                },
                {
                    "columnName": "b",
                    "nullCount": "0",
                    "minValue": "",
                    "maxValue": "",
                    "cardinality": "0",
                    "density": "0x0p+0",
                    "sampleSize": "0",
                    "lastUpdated": "0"
                },
                {
                    "columnName": "t",
                    "nullCount": "0",
                    "minValue": "",
                    "maxValue": "",
                    "cardinality": "0",
                    "density": "0x0p+0",
                    "sampleSize": "0",
                    "lastUpdated": "0"
                }
            ]
        }
    ],
    "stats": [
        {
            "tableName": "t",
            "columns": [
                {
                    "columnName": "a"
                },
                {
                    "columnName": "b"
                },
                {
                    "columnName": "t"
                }
            ]
        }
    ]
}
],
        "query_after_rewrites":"INSERT INTO `db`.`temp` (`temp`.`a`, `temp`.`b`, `temp`.`t`) SELECT `unaliased subselect`.`a` AS `a`, `unaliased subselect`.`b` AS `b`, `unaliased subselect`.`t` AS `t` FROM  ( SELECT `t`.`a` AS `a`, `t`.`b` AS `b`, `t`.`t` AS `t` FROM  `db`.`t` as `t`  ) AS `unaliased subselect`"
        }
    }
Executing query (query: 'SET SESSION profile_for_debug=0', args: '[]')
Executing query (query: 'DROP TEMPORARY TABLE temp', args: '[]')
Executing query (query: 'CREATE RESULT TABLE `goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` AS SELECT * FROM (SELECT * FROM t)', args: '[[]]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 7', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 4', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 1', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 2', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 5', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 3', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 6', args: '[]')
Executing query (query: 'SELECT * FROM ::`goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059` WHERE partition_id() = 0', args: '[]')
Executing query (query: 'DROP RESULT TABLE `goArrowResultTable_cd36a2072e7f9deaa746db7480200944_8259059`', args: '[]')
```